### PR TITLE
Fix Autoloading Issue

### DIFF
--- a/app/models/journaled/delivery.rb
+++ b/app/models/journaled/delivery.rb
@@ -80,6 +80,6 @@ class Journaled::Delivery
     )
   end
 
-  class KinesisTemporaryFailure < NotTrulyExceptionalError
+  class KinesisTemporaryFailure < Journaled::NotTrulyExceptionalError
   end
 end


### PR DESCRIPTION
With the new default autoloader in Rails 6 Journaled was failing to find
the `NotTrulyExceptionalError` error usage in `Journaled::Delivery`

To fix this I simply explicitly specified the namespaced version,
`Journaled::NotTrulyExceptionalError`