### PR TITLE
Retry Failed Records

### DIFF
--- a/app/models/journaled/bulk_delivery.rb
+++ b/app/models/journaled/bulk_delivery.rb
@@ -49,7 +49,7 @@ class Journaled::BulkDelivery
     raise 'FailedRecordCount differs from count of records that have errors' unless errored_records.count == failed_record_count
     raise 'ALL Records failed to be added to the Kinesis steam' if errored_records.count == records.count
 
-    Delayed::Job.enqueue self.class.new(records: errored_records, app_name: app_name)
+    Delayed::Job.enqueue self.class.new(records: errored_records, app_name: app_name) if errored_records.any?
   end
 
   class KinesisTemporaryFailure < Journaled::NotTrulyExceptionalError

--- a/app/models/journaled/bulk_delivery.rb
+++ b/app/models/journaled/bulk_delivery.rb
@@ -45,10 +45,11 @@ class Journaled::BulkDelivery
     records_with_responses = records.zip(response.records)
     errored_records = records_with_responses.select { |_record, resp| resp.error_code.present? }.map(&:first)
 
-    raise 'FailedRecordCount differs from count of records that have errors' unless errored_records.count == response.failed_record_count
+    failed_record_count = response.failed_record_count || 0
+    raise 'FailedRecordCount differs from count of records that have errors' unless errored_records.count == failed_record_count
     raise 'ALL Records failed to be added to the Kinesis steam' if errored_records.count == records.count
 
-    Delayed::Job.enqueue self.class.new(records: y, app_name: app_name) # This won't have the same enqueue opts as the orig job
+    Delayed::Job.enqueue self.class.new(records: errored_records, app_name: app_name)
   end
 
   class KinesisTemporaryFailure < Journaled::NotTrulyExceptionalError

--- a/app/models/journaled/bulk_delivery.rb
+++ b/app/models/journaled/bulk_delivery.rb
@@ -46,6 +46,7 @@ class Journaled::BulkDelivery
     errored_records = records_with_responses.select { |_record, resp| resp.error_code.present? }.map(&:first)
 
     raise 'FailedRecordCount differs from count of records that have errors' unless errored_records.count == response.failed_record_count
+    raise 'ALL Records failed to be added to the Kinesis steam' if errored_records.count == records.count
 
     Delayed::Job.enqueue self.class.new(records: y, app_name: app_name) # This won't have the same enqueue opts as the orig job
   end

--- a/app/models/journaled/bulk_delivery.rb
+++ b/app/models/journaled/bulk_delivery.rb
@@ -8,7 +8,7 @@ class Journaled::BulkDelivery
     return unless Journaled.enabled?
 
     response = kinesis_client.put_records request
-    reenqueue_failed_records!(response)
+    requeue_failed_records!(response)
   rescue Aws::Kinesis::Errors::InternalFailure, Aws::Kinesis::Errors::ServiceUnavailable, Aws::Kinesis::Errors::Http503Error => e
     Rails.logger.error "Kinesis Error - Server Error occurred - #{e.class}"
     raise KinesisTemporaryFailure
@@ -41,7 +41,7 @@ class Journaled::BulkDelivery
     Journaled::KinesisClient.generate
   end
 
-  def reenqueue_failed_records!(response) # rubocop:disable Metrics/AbcSize
+  def requeue_failed_records!(response) # rubocop:disable Metrics/AbcSize
     records_with_responses = records.zip(response.records)
     errored_records = records_with_responses.select { |_record, resp| resp.error_code.present? }.map(&:first)
 

--- a/spec/models/journaled/bulk_delivery_spec.rb
+++ b/spec/models/journaled/bulk_delivery_spec.rb
@@ -137,7 +137,7 @@ RSpec.describe Journaled::BulkDelivery do
         }
       end
 
-      it 're-enqueues the failing records' do
+      it 'requeues the failing records' do
         expect { subject.perform }.to change { Delayed::Job.count }.from(0).to(1)
 
         job = Delayed::Job.last
@@ -183,7 +183,7 @@ RSpec.describe Journaled::BulkDelivery do
         }
       end
 
-      it 'raises causing the job to reenqueue' do
+      it 'raises' do
         expect { subject.perform }.to raise_error('ALL Records failed to be added to the Kinesis steam')
       end
     end

--- a/spec/models/journaled/bulk_delivery_spec.rb
+++ b/spec/models/journaled/bulk_delivery_spec.rb
@@ -41,11 +41,7 @@ RSpec.describe Journaled::BulkDelivery do
 
     it 'makes requests to AWS to put the events on the Kinesis with the correct bodies' do
       allow(kinesis_client).to receive(:put_records).and_call_original
-      response = subject.perform
-
-      event = response.records.first
-      expect(event.shard_id).to eq '101'
-      expect(event.sequence_number).to eq '101123'
+      subject.perform
 
       expect(kinesis_client).to have_received(:put_records)
         .with(
@@ -153,7 +149,7 @@ RSpec.describe Journaled::BulkDelivery do
       context 'when the number of failing records conflicts with the given count' do
         let(:return_status_body) do
           {
-            failed_record_count: 1,
+            failed_record_count: 2,
             records: [
               {
                 error_code: 'ProvisionedThroughputExceededException',

--- a/spec/models/journaled/bulk_delivery_spec.rb
+++ b/spec/models/journaled/bulk_delivery_spec.rb
@@ -166,7 +166,7 @@ RSpec.describe Journaled::BulkDelivery do
       end
     end
 
-    context 'when ALL of the events fails' do
+    context 'when ALL of the events fail' do
       let(:return_status_body) do
         {
           failed_record_count: 2,

--- a/spec/models/journaled/bulk_delivery_spec.rb
+++ b/spec/models/journaled/bulk_delivery_spec.rb
@@ -41,7 +41,7 @@ RSpec.describe Journaled::BulkDelivery do
 
     it 'makes requests to AWS to put the events on the Kinesis with the correct bodies' do
       allow(kinesis_client).to receive(:put_records).and_call_original
-      subject.perform
+      expect { subject.perform }.not_to change { Delayed::Job.count }
 
       expect(kinesis_client).to have_received(:put_records)
         .with(


### PR DESCRIPTION
This fixes a pretty unfortunate bug in how I rolled out the Bulk Journaling here the first time :panic:

I was under the impression that the `putRecords` endpoint would be atomic, in that either it would succeed or the whole batch would fail. However that isn't the case, and it is definitely possible for individual records to succeed or fail on their own.

This PR adds a relatively simple patch for dealing with this! It looks at the putRecords resonse, and re-enqueues the records which failed!

It definitely gets the job done, but there are a few rough edges I want to smooth out before we upstream, but I think this is likely good to get testing! (Comments inline for future work!)
