### PR TITLE
Bulk Delivery Error Improvements

### DIFF
--- a/app/models/journaled/bulk_delivery.rb
+++ b/app/models/journaled/bulk_delivery.rb
@@ -88,8 +88,8 @@ class Journaled::BulkDelivery
       @error_objects ||= begin
                            grouped_errors = errors.group_by(&:error_code).to_a
 
-                           grouped_errors.map do |error_code, r|
-                             error_class_for_code(error_code).new(r.map(&:error_message).join("\n"))
+                           grouped_errors.map do |error_code, group|
+                             error_class_for_code(error_code).new(group.map(&:error_message).join("\n"))
                            end
                          end
     end

--- a/app/models/journaled/bulk_delivery.rb
+++ b/app/models/journaled/bulk_delivery.rb
@@ -8,7 +8,7 @@ class Journaled::BulkDelivery
     return unless Journaled.enabled?
 
     response = kinesis_client.put_records request
-    requeue_failed_records!(response)
+    handle_failures!(response)
   rescue Aws::Kinesis::Errors::InternalFailure, Aws::Kinesis::Errors::ServiceUnavailable, Aws::Kinesis::Errors::Http503Error => e
     Rails.logger.error "Kinesis Error - Server Error occurred - #{e.class}"
     raise KinesisTemporaryFailure
@@ -41,41 +41,86 @@ class Journaled::BulkDelivery
     Journaled::KinesisClient.generate
   end
 
-  def requeue_failed_records!(response) # rubocop:disable Metrics/AbcSize
-    records_with_responses = records.zip(response.records)
-    errored_records_with_responses = records_with_responses.select { |_record, resp| resp.error_code.present? }
-    errored_records = errored_records_with_responses.map(&:first)
+  def handle_failures!(response)
+    ErrorHandler.new(response, records, app_name).handle!
+  end
 
-    failed_record_count = response.failed_record_count || 0
-    raise 'FailedRecordCount differs from count of records that have errors' unless errored_records.count == failed_record_count
+  class ErrorHandler
+    attr_reader :response, :records, :app_name
 
-    if errored_records.count == records.count
-      errors = errored_records_with_responses.map(&:second)
-      grouped_errors = errors.group_by(&:error_code).to_a
+    def initialize(response, records, app_name)
+      @response = response
+      @records = records
+      @app_name = app_name
+    end
 
-      error_objs = grouped_errors.map do |error_code, r|
-        klass = if error_code == 'ProvisionedThroughputExceededException'
-                  KinesisBulkRateLimitFailure
-                else
-                  KinesisBulkInternalErrorFailure
-                end
+    def handle!
+      handle_failed_record_count!
+      handle_all_records_failed!
+      renenqueue_failed_records!
+    end
 
-        klass.new(r.map(&:error_message).join("\n"))
-      end
+    private
 
-      if error_objs.count == 1
-        raise(error_objs.first)
-      else
-        raise MultipleErrorsFailure, error_objs
+    def handle_failed_record_count!
+      failed_record_count = response.failed_record_count || 0
+
+      unless errored_records_with_responses.count == failed_record_count
+        raise 'FailedRecordCount differs from count of records that have errors'
       end
     end
 
-    Delayed::Job.enqueue self.class.new(records: errored_records, app_name: app_name) if errored_records.any?
+    def handle_all_records_failed!
+      return unless errored_records.count == records.count
+
+      if error_objects.count == 1
+        raise(error_objects.first)
+      else
+        raise MultipleErrorsFailure, error_objects
+      end
+    end
+
+    def renenqueue_failed_records!
+      Delayed::Job.enqueue Journaled::BulkDelivery.new(records: errored_records, app_name: app_name) if errored_records.any?
+    end
+
+    def error_objects
+      @error_objects ||= begin
+                           grouped_errors = errors.group_by(&:error_code).to_a
+
+                           grouped_errors.map do |error_code, r|
+                             error_class_for_code(error_code).new(r.map(&:error_message).join("\n"))
+                           end
+                         end
+    end
+
+    def error_class_for_code(error_code)
+      if error_code == 'ProvisionedThroughputExceededException'
+        KinesisBulkRateLimitFailure
+      else
+        KinesisBulkInternalErrorFailure
+      end
+    end
+
+    def errored_records
+      errored_records_with_responses.map(&:first)
+    end
+
+    def errors
+      errored_records_with_responses.map(&:second)
+    end
+
+    def errored_records_with_responses
+      @errored_records_with_responses ||= records_with_responses.select { |_record, resp| resp.error_code.present? }
+    end
+
+    def records_with_responses
+      @records_with_responses ||= records.zip(response.records)
+    end
   end
 
   class KinesisTemporaryFailure < Journaled::NotTrulyExceptionalError
   end
-
   class KinesisBulkInternalErrorFailure < Journaled::NotTrulyExceptionalError
   end
   class KinesisBulkRateLimitFailure < StandardError

--- a/app/models/journaled/bulk_delivery.rb
+++ b/app/models/journaled/bulk_delivery.rb
@@ -55,14 +55,14 @@ class Journaled::BulkDelivery
     end
 
     def handle!
-      handle_failed_record_count!
+      handle_failed_record_count_mismatch!
       handle_all_records_failed!
       renenqueue_failed_records!
     end
 
     private
 
-    def handle_failed_record_count!
+    def handle_failed_record_count_mismatch!
       failed_record_count = response.failed_record_count || 0
 
       unless errored_records_with_responses.count == failed_record_count

--- a/spec/models/journaled/bulk_delivery_spec.rb
+++ b/spec/models/journaled/bulk_delivery_spec.rb
@@ -166,7 +166,7 @@ RSpec.describe Journaled::BulkDelivery do
       end
     end
 
-    context 'when ALL of the events fail' do
+    context 'when ALL of the events fail with the same error code' do
       let(:return_status_body) do
         {
           failed_record_count: 2,
@@ -184,7 +184,7 @@ RSpec.describe Journaled::BulkDelivery do
       end
 
       it 'raises' do
-        expect { subject.perform }.to raise_error('ALL Records failed to be added to the Kinesis steam')
+        expect { subject.perform }.to raise_error(described_class::KinesisBulkRateLimitFailure, /Rate exceeded for shard shardId\-000000000001/)
       end
     end
   end


### PR DESCRIPTION
This improves the Errors that are raised by the BulkDelivery job.

It now raises a specific type of error if all the records failed for the same reason. The main reason for this is to be able to isolate when jobs are failing just due to rate limiting.
It raises a mixed error if records fail for multiple reasons but forwards the error messages so they can be reported on and handled.

This still just silently ignores errors (and re-enqueues) when not the whole batch fails. In theory if the failure is persistent, eventually records will fail all together, but its not the best approach I don't think. Think doesn't solve that yet, but might as well be iterative right?