### PR TITLE
Depend on Kinesis Specifically instead of all AWS Resources

### DIFF
--- a/journaled.gemspec
+++ b/journaled.gemspec
@@ -17,7 +17,7 @@ Gem::Specification.new do |s|
   s.files = Dir['{app,config,lib,journaled_schemas}/**/*', 'LICENSE', 'Rakefile', 'README.md']
   s.test_files = Dir['spec/**/*']
 
-  s.add_dependency 'aws-sdk-resources', '< 4'
+  s.add_dependency 'aws-sdk-kinesis', '< 2'
   s.add_dependency 'delayed_job'
   s.add_dependency 'json-schema'
   s.add_dependency 'rails', '>= 5.1', '< 7.0'

--- a/lib/journaled.rb
+++ b/lib/journaled.rb
@@ -1,4 +1,4 @@
-require 'aws-sdk-resources'
+require 'aws-sdk-kinesis'
 require 'delayed_job'
 require 'json-schema'
 require 'request_store'


### PR DESCRIPTION
This brings down the dependecies of Journaled by a LOT!

I ran into this while trying to get Rails 6.1 setup in our app.

Rails now needs a newer version of S3, but it conflicts with versions from Journaled so dropping this to make that easier!