### PR TITLE
Add ability to specify a job_queue for all Journaled jobs 

### DIFF
--- a/lib/journaled.rb
+++ b/lib/journaled.rb
@@ -10,6 +10,7 @@ require 'journaled/stream_name.rb'
 module Journaled
   mattr_accessor :default_app_name
   mattr_accessor(:job_priority) { 20 }
+  mattr_accessor :job_queue
 
   def development_or_test?
     %w(development test).include?(Rails.env)

--- a/lib/journaled/enqueue.rb
+++ b/lib/journaled/enqueue.rb
@@ -7,7 +7,7 @@ module Journaled
     private
 
     def delayed_job_enqueue(*args, **opts)
-      Delayed::Job.enqueue(*args, **opts.reverse_merge(priority: Journaled.job_priority))
+      Delayed::Job.enqueue(*args, **opts.reverse_merge(priority: Journaled.job_priority, queue: Journaled.job_queue))
     end
   end
 end

--- a/spec/models/journaled/writer_spec.rb
+++ b/spec/models/journaled/writer_spec.rb
@@ -65,6 +65,21 @@ RSpec.describe Journaled::Writer do
         end
       end
 
+      context 'when no queue is provided in enqueue_opts' do
+        around do |example|
+          old_queue = Journaled.job_queue
+          Journaled.job_queue = 'custom-queue'
+          example.run
+          Journaled.job_queue = old_queue
+        end
+
+        it 'defaults to the global default' do
+          expect { subject.journal! }.to change {
+            Delayed::Job.where('handler like ?', '%Journaled::Delivery%').where(queue: 'custom-queue').count
+          }.from(0).to(1)
+        end
+      end
+
       context 'when there is a job priority specified in the enqueue opts' do
         let(:journaled_enqueue_opts) { { priority: 13 } }
 


### PR DESCRIPTION
This adds a `Journaled.job_queue` option that can be set to give all
Journaled jobs a specific queue to enqueue into.