### PR TITLE
Make the bulk delivery limit configurable with an environment variable

### DIFF
--- a/app/models/journaled/bulk_writer.rb
+++ b/app/models/journaled/bulk_writer.rb
@@ -18,7 +18,7 @@ class Journaled::BulkWriter
 
   def enqueue_deliveries!
     now = Time.zone.now
-    serializers.each_slice(Journaled.bulk_delivery_limit).each_with_index.each do |serializers, index|
+    serializers.each_slice(Journaled.bulk_delivery_chunk_limit).each_with_index.each do |serializers, index|
       enqueue_delivery!(serializers, now + (index * per_job_delay))
     end
   end

--- a/lib/journaled.rb
+++ b/lib/journaled.rb
@@ -20,8 +20,8 @@ module Journaled
     !['0', 'false', false, 'f', ''].include?(ENV.fetch('JOURNALED_ENABLED', !development_or_test?))
   end
 
-  def bulk_delivery_limit
-    ENV.fetch('JOURNALED_BULK_DELIVERY_LIMIT', 500)
+  def bulk_delivery_chunk_limit
+    ENV.fetch('JOURNALED_BULK_DELIVERY_CHUNK_LIMIT', 500).to_i
   end
 
   def schema_providers
@@ -36,5 +36,6 @@ module Journaled
     Journaled::ActorUriProvider.instance.actor_uri
   end
 
-  module_function :development_or_test?, :enabled?, :bulk_delivery_limit, :schema_providers, :commit_hash, :actor_uri
+  module_function :development_or_test?, :enabled?, :schema_providers, :commit_hash, :actor_uri,
+                  :bulk_delivery_chunk_limit
 end

--- a/spec/lib/journaled_spec.rb
+++ b/spec/lib/journaled_spec.rb
@@ -65,4 +65,16 @@ RSpec.describe Journaled do
       expect(ENV).to have_received(:fetch).with('MY_FUNKY_APP_NAME_JOURNALED_STREAM_NAME')
     end
   end
+
+  describe '.bulk_delivery_chunk_limit' do
+    it 'returns a default when there is no environment variable' do
+      expect(described_class.bulk_delivery_chunk_limit).to eq 500
+    end
+
+    it 'returns the limit specified in the environment when set' do
+      with_env(JOURNALED_BULK_DELIVERY_CHUNK_LIMIT: 200) do
+        expect(described_class.bulk_delivery_chunk_limit).to eq 200
+      end
+    end
+  end
 end

--- a/spec/models/journaled/bulk_writer_spec.rb
+++ b/spec/models/journaled/bulk_writer_spec.rb
@@ -67,7 +67,7 @@ RSpec.describe Journaled::BulkWriter do
 
       context 'when the number of events passed in exceeds EVENTS_PER_DELIVERY' do
         before do
-          allow(Journaled).to receive(:bulk_delivery_limit).and_return(1)
+          allow(Journaled).to receive(:bulk_delivery_chunk_limit).and_return(1)
         end
 
         it 'creates multiple deliveries' do


### PR DESCRIPTION
Alternative to https://github.com/WellSheet/journaled/pull/8 since we're not sure what to do with single events that are over the size limit. This doesn't solve that problem -- it would just keep alerting like it is now -- but it'll at least solve _our_ problem because we can adjust the bulk delivery limit down until the alerting chart is back under the threshold.