### PR TITLE
Fix DJ #enqueue calls that cause deprecation warnings in Ruby 3

### DIFF
--- a/app/models/journaled/bulk_writer.rb
+++ b/app/models/journaled/bulk_writer.rb
@@ -32,7 +32,7 @@ class Journaled::BulkWriter
         records: serialized_events.zip(partition_keys),
         app_name: app_name,
       ),
-      enqueue_opts.merge(run_at: run_at),
+      **enqueue_opts.merge(run_at: run_at),
     )
   end
 

--- a/app/models/journaled/writer.rb
+++ b/app/models/journaled/writer.rb
@@ -6,7 +6,7 @@ class Journaled::Writer
   def journal!
     serializer.serialize!
 
-    Journaled.enqueue!(journaled_delivery, journaled_enqueue_opts)
+    Journaled.enqueue!(journaled_delivery, **journaled_enqueue_opts)
   end
 
   private

--- a/lib/journaled/enqueue.rb
+++ b/lib/journaled/enqueue.rb
@@ -1,7 +1,7 @@
 module Journaled
   class << self
-    def enqueue!(*args)
-      delayed_job_enqueue(*args)
+    def enqueue!(*args, **opts)
+      delayed_job_enqueue(*args, **opts)
     end
 
     private


### PR DESCRIPTION
Hashes need to be splatted into keyword arguments in Ruby 3, so fixing a few spots where that conversion wasn't happening. This fixes deprecation warnings from delayed_job that look like:

```
[DEPRECATION] Passing multiple arguments to `#enqueue` is deprecated. Pass a hash with :priority and :run_at.
```
