### PR TITLE
Remove force option on updates and deletes that go around validation

### DIFF
--- a/app/models/concerns/journaled/changes.rb
+++ b/app/models/concerns/journaled/changes.rb
@@ -26,31 +26,26 @@ module Journaled::Changes
   end
 
   if Rails::VERSION::MAJOR > 5 || (Rails::VERSION::MAJOR == 5 && Rails::VERSION::MINOR >= 2)
-    def delete(force: false)
-      if force || self.class.journaled_attribute_names.empty?
-        super()
-      else
-        raise(<<~ERROR)
-          #delete aborted by Journaled::Changes.
-
-          Call #destroy instead to ensure journaling or invoke #delete(force: true)
-          to override and skip journaling.
-        ERROR
+    def delete
+      unless self.class.journaled_attribute_names.empty?
+        raise('#delete aborted by Journaled::Changes. Call #destroy instead to ensure journaling.')
       end
+
+      super()
     end
 
-    def update_columns(attributes, force: false)
-      unless force || self.class.journaled_attribute_names.empty?
+    def update_columns(attributes)
+      unless self.class.journaled_attribute_names.empty?
         conflicting_journaled_attribute_names = self.class.journaled_attribute_names & attributes.keys.map(&:to_sym)
         raise(<<~ERROR) if conflicting_journaled_attribute_names.present?
           #update_columns aborted by Journaled::Changes due to journaled attributes:
 
             #{conflicting_journaled_attribute_names.join(', ')}
 
-          Call #update instead to ensure journaling or invoke #update_columns
-          with additional arg `{ force: true }` to override and skip journaling.
+          Call #update instead to ensure journaling.
         ERROR
       end
+
       super(attributes)
     end
   end
@@ -69,17 +64,12 @@ module Journaled::Changes
     end
 
     if Rails::VERSION::MAJOR > 5 || (Rails::VERSION::MAJOR == 5 && Rails::VERSION::MINOR >= 2)
-      def delete(id_or_array, force: false)
-        if force || journaled_attribute_names.empty?
-          where(primary_key => id_or_array).delete_all(force: true)
-        else
-          raise(<<~ERROR)
-            .delete aborted by Journaled::Changes.
-
-            Call .destroy(id_or_array) instead to ensure journaling or invoke
-            .delete(id_or_array, force: true) to override and skip journaling.
-          ERROR
+      def delete(id_or_array)
+        unless journaled_attribute_names.empty?
+          raise('.delete aborted by Journaled::Changes. Call .destroy(id_or_array) instead to ensure journaling.')
         end
+
+        super(id_or_array)
       end
     end
   end

--- a/lib/journaled/relation_change_protection.rb
+++ b/lib/journaled/relation_change_protection.rb
@@ -1,6 +1,6 @@
 module Journaled::RelationChangeProtection
-  def update_all(updates, force: false) # rubocop:disable Metrics/MethodLength, Metrics/AbcSize, Metrics/PerceivedComplexity
-    unless force || !@klass.respond_to?(:journaled_attribute_names) || @klass.journaled_attribute_names.empty?
+  def update_all(updates) # rubocop:disable Metrics/MethodLength, Metrics/AbcSize, Metrics/PerceivedComplexity
+    if @klass.respond_to?(:journaled_attribute_names) && !@klass.journaled_attribute_names.empty?
       conflicting_journaled_attribute_names = if updates.is_a?(Hash)
                                                 @klass.journaled_attribute_names & updates.keys.map(&:to_sym)
                                               elsif updates.is_a?(String)
@@ -15,23 +15,18 @@ module Journaled::RelationChangeProtection
 
           #{conflicting_journaled_attribute_names.join(', ')}
 
-        Consider using .all(lock: true) or .find_each with #update to ensure journaling or invoke
-         .update_all with additional arg `{ force: true }` to override and skip journaling.
+        Consider using .all(lock: true) or .find_each with #update to ensure journaling.
       ERROR
     end
+
     super(updates)
   end
 
-  def delete_all(force: false)
-    if force || !@klass.respond_to?(:journaled_attribute_names) || @klass.journaled_attribute_names.empty?
-      super()
-    else
-      raise(<<~ERROR)
-        #delete_all aborted by Journaled::Changes.
-
-        Call .destroy_all instead to ensure journaling or invoke .delete_all(force: true)
-        to override and skip journaling.
-      ERROR
+  def delete_all
+    if @klass.respond_to?(:journaled_attribute_names) && !@klass.journaled_attribute_names.empty?
+      raise('#delete_all aborted by Journaled::Changes. Call .destroy_all instead to ensure journaling.')
     end
+
+    super()
   end
 end

--- a/spec/models/database_change_protection_spec.rb
+++ b/spec/models/database_change_protection_spec.rb
@@ -33,10 +33,6 @@ if Rails::VERSION::MAJOR > 5 || (Rails::VERSION::MAJOR == 5 && Rails::VERSION::M
         it 'succeeds on unjournaled columns' do
           expect { journaled_class.update_all(handler: '') }.not_to raise_error
         end
-
-        it 'succeeds when forced on journaled columns' do
-          expect { journaled_class.update_all({ locked_at: nil }, force: true) }.not_to raise_error
-        end
       end
 
       describe '#delete' do
@@ -47,10 +43,6 @@ if Rails::VERSION::MAJOR > 5 || (Rails::VERSION::MAJOR == 5 && Rails::VERSION::M
         it 'succeeds if no journaled columns exist' do
           expect { journaled_class_with_no_journaled_columns.delete(1) }.not_to raise_error
         end
-
-        it 'succeeds if journaled columns exist when forced' do
-          expect { journaled_class.delete(1, force: true) }.not_to raise_error
-        end
       end
 
       describe '#delete_all' do
@@ -60,10 +52,6 @@ if Rails::VERSION::MAJOR > 5 || (Rails::VERSION::MAJOR == 5 && Rails::VERSION::M
 
         it 'succeeds if no journaled columns exist' do
           expect { journaled_class_with_no_journaled_columns.delete_all }.not_to raise_error
-        end
-
-        it 'succeeds if journaled columns exist when forced' do
-          expect { journaled_class.delete_all(force: true) }.not_to raise_error
         end
       end
     end
@@ -89,10 +77,6 @@ if Rails::VERSION::MAJOR > 5 || (Rails::VERSION::MAJOR == 5 && Rails::VERSION::M
         it 'succeeds on unjournaled columns' do
           expect { subject.update_columns(handler: '') }.not_to raise_error
         end
-
-        it 'succeeds when forced on journaled columns' do
-          expect { subject.update_columns({ locked_at: nil }, force: true) }.not_to raise_error
-        end
       end
 
       describe '#delete' do
@@ -103,10 +87,6 @@ if Rails::VERSION::MAJOR > 5 || (Rails::VERSION::MAJOR == 5 && Rails::VERSION::M
         it 'succeeds if no journaled columns exist' do
           instance = journaled_class_with_no_journaled_columns.enqueue(job)
           expect { instance.delete }.not_to raise_error
-        end
-
-        it 'succeeds if journaled columns exist when forced' do
-          expect { subject.delete(force: true) }.not_to raise_error
         end
       end
     end


### PR DESCRIPTION
Another change for Ruby 3 compatibility, but rather than trying to make it work correctly with the new semantics, I'm just removing the option because we don't force any updates or deletes anywhere.